### PR TITLE
Add support for `__typename`

### DIFF
--- a/lib/graphql/cardinal/executor.rb
+++ b/lib/graphql/cardinal/executor.rb
@@ -14,6 +14,8 @@ module GraphQL
       include Coercion
       include ResponseShape
 
+      TYPENAME_FIELD = "__typename"
+
       attr_reader :exec_count
 
       def initialize(schema, resolvers, document, root_object)
@@ -140,6 +142,7 @@ module GraphQL
         parent_sources = exec_scope.sources
         parent_responses = exec_scope.responses
         field_key = exec_field.key
+        field_name = exec_field.name
         field_type = exec_field.type
         return_type = field_type.unwrap
 
@@ -166,7 +169,7 @@ module GraphQL
             next_responses_by_type = Hash.new { |h, k| h[k] = [] }
             next_sources.each_with_index do |source, i|
               impl_type = type_resolver.call(source, @context)
-              next_sources_by_type[impl_type] << source
+              next_sources_by_type[impl_type] << (field_name == TYPENAME_FIELD ? impl_type.graphql_name : source)
               next_responses_by_type[impl_type] << next_responses[i].tap { |r| r.typename = impl_type.graphql_name }
             end
 

--- a/lib/graphql/cardinal/field_resolvers.rb
+++ b/lib/graphql/cardinal/field_resolvers.rb
@@ -21,5 +21,12 @@ module GraphQL
         objects.map { _1[@key] }
       end
     end
+
+    class TypenameResolver < FieldResolver
+      def resolve(objects, _args, _ctx, scope)
+        typename = scope.parent_type.graphql_name.freeze
+        objects.map { typename }
+      end
+    end
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -59,15 +59,18 @@ end
 BREADTH_ESOLVERS = {
   "Node" => {
     "id" => GraphQL::Cardinal::HashKeyResolver.new("id"),
-    "__type__" => ->(obj, ctx) { ctx[:query].get_type(obj["__typename"]) },
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
+    "__type__" => ->(obj, ctx) { ctx[:query].get_type(obj["__typename__"]) },
   },
   "HasMetafields" => {
     "metafield" => GraphQL::Cardinal::HashKeyResolver.new("metafield"),
-    "__type__" => ->(obj, ctx) { ctx[:query].get_type(obj["__typename"]) },
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
+    "__type__" => ->(obj, ctx) { ctx[:query].get_type(obj["__typename__"]) },
   },
   "Metafield" => {
     "key" => GraphQL::Cardinal::HashKeyResolver.new("key"),
     "value" => GraphQL::Cardinal::HashKeyResolver.new("value"),
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
   },
   "Product" => {
     "id" => GraphQL::Cardinal::HashKeyResolver.new("id"),
@@ -76,27 +79,34 @@ BREADTH_ESOLVERS = {
     "must" => GraphQL::Cardinal::HashKeyResolver.new("must"),
     "variants" => GraphQL::Cardinal::HashKeyResolver.new("variants"),
     "metafield" => GraphQL::Cardinal::HashKeyResolver.new("metafield"),
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
   },
   "ProductConnection" => {
     "nodes" => GraphQL::Cardinal::HashKeyResolver.new("nodes"),
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
   },
   "Variant" => {
     "id" => GraphQL::Cardinal::HashKeyResolver.new("id"),
     "title" => GraphQL::Cardinal::HashKeyResolver.new("title"),
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
   },
   "VariantConnection" => {
     "nodes" => GraphQL::Cardinal::HashKeyResolver.new("nodes"),
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
   },
   "WriteValuePayload" => {
     "value" => GraphQL::Cardinal::HashKeyResolver.new("value"),
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
   },
   "Query" => {
     "products" => GraphQL::Cardinal::HashKeyResolver.new("products"),
     "nodes" => GraphQL::Cardinal::HashKeyResolver.new("nodes"),
     "node" => GraphQL::Cardinal::HashKeyResolver.new("node"),
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
   },
   "Mutation" => {
     "writeValue" => WriteValueResolver.new,
+    "__typename" => GraphQL::Cardinal::TypenameResolver.new,
   },
 }.freeze
 

--- a/test/graphql/cardinal/breadth_executor_test.rb
+++ b/test/graphql/cardinal/breadth_executor_test.rb
@@ -7,6 +7,35 @@ class GraphQL::Cardinal::ExecutorTest < Minitest::Test
     assert_equal BASIC_SOURCE, breadth_exec(BASIC_DOCUMENT, BASIC_SOURCE).dig("data")
   end
 
+  def test_resolves_typename_field
+    document = %|{
+      products(first: 1) {
+        nodes {
+          __typename
+        }
+      }
+      node(id: "Product/1") {
+        __typename
+      }
+    }|
+
+    source = {
+      "products" => {
+        "nodes" => [{}],
+      },
+      "node" => { "__typename__" => "Product" },
+    }
+
+    expected = {
+      "products" => {
+        "nodes" => [{ "__typename" => "Product" }],
+      },
+      "node" => { "__typename" => "Product" },
+    }
+
+    assert_equal expected, breadth_exec(document, source).dig("data")
+  end
+
   def test_follows_skip_directives
     document = %|{
       products(first: 3) {
@@ -70,7 +99,7 @@ class GraphQL::Cardinal::ExecutorTest < Minitest::Test
       "node" => {
         "title" => "Banana",
         "metafield" => { "key" => "test", "value" => "okay" },
-        "__typename" => "Product",
+        "__typename__" => "Product",
       },
     }
 
@@ -105,7 +134,7 @@ class GraphQL::Cardinal::ExecutorTest < Minitest::Test
       "node" => {
         "title" => "Banana",
         "metafield" => { "key" => "test", "value" => "okay" },
-        "__typename" => "Product",
+        "__typename__" => "Product",
       },
     }
 
@@ -127,7 +156,7 @@ class GraphQL::Cardinal::ExecutorTest < Minitest::Test
     }|
 
     source = {
-      "node" => { "id" => "Product/1", "__typename" => "Product" },
+      "node" => { "id" => "Product/1", "__typename__" => "Product" },
     }
 
     expected = {
@@ -151,8 +180,8 @@ class GraphQL::Cardinal::ExecutorTest < Minitest::Test
 
     source = {
       "nodes" => [
-        { "id" => "Product/1", "title" => "Product 1", "__typename" => "Product" },
-        { "id" => "Variant/1", "title" => "Variant 1", "__typename" => "Variant" },
+        { "id" => "Product/1", "title" => "Product 1", "__typename__" => "Product" },
+        { "id" => "Variant/1", "title" => "Variant 1", "__typename__" => "Variant" },
       ],
     }
 


### PR DESCRIPTION
Adds support for the `__typename` field, which needs to be added manually into the resolver map for now (this would be something to automate). Abstract types have their names adjusted later after being resolved into concrete types.