### PR TITLE
Inline ordered selections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 **An (experimental) breadth-first GraphQL executor for Ruby**
 
-Depth-first execution resolves every object field descending down a response tree, while breadth-first visits every _selection position_ once with an aggregated set of objects. A breadth-first approach makes resolver overhead dramatically cheaper when resolvers only scale by the size of the request document rather than the size of the response.
+Depth-first execution resolves every object field descending down a response tree, while breadth-first visits every _selection position_ once with an aggregated set of objects. The breadth-first approach tends to be much faster due to fewer resolver calls and intermediary promises.
 
 ```shell
 graphql-ruby: 140002 resolvers
-    1.159 (± 0.0%) i/s  (862.55 ms/i) - 6.000 in 5.182856s
+   1.087 (± 0.0%) i/s  (919.76 ms/i) -  6.000 in  5.526807s
 graphql-cardinal 140002 resolvers
-    19.251 (±10.4%) i/s   (51.95 ms/i) - 95.000 in 5.007853s
+   21.314 (± 9.4%) i/s   (46.92 ms/i) -  108.000 in  5.095015s
 
 Comparison:
-graphql-cardinal 140002 resolvers:     19.3 i/s
-graphql-ruby: 140002 resolvers:     1.2 i/s - 16.60x  slower
+graphql-cardinal 140002 resolvers:   21.3 i/s
+graphql-ruby: 140002 resolvers:   1.1 i/s - 19.60x  slower
 ```
 
 ### Depth vs. Breadth
@@ -23,7 +23,7 @@ GraphQL requests have two dimensions: _depth_ and _breadth_. The depth dimension
 
 ### Depth-first execution
 
-Depth-first execution (the conventional GraphQL execution strategy) resolves every field in the response by descending down the selection tree of every object. This overhead scales linearly as the response size grows, and balloons quickly with added field tracing and instrumentation.
+Depth-first execution (the conventional GraphQL execution strategy) resolves every field in the response by descending down the selection tree of every object. This overhead scales as the response size grows, and balloons quickly with added field tracing and instrumentation.
 
 ![Depth](./images/depth-first.png)
 
@@ -41,7 +41,7 @@ Breadth-first then runs a single resolver per document selection, and coalesces 
 
 ![Breadth](./images/breadth-first.png)
 
-While bigger responses will always take longer to process, the workload is almost entirely your own business logic rather than GraphQL execution overhead. Other advantages:
+While bigger responses will always take longer to process, the workload is your own business logic with very little GraphQL execution overhead. Other advantages:
 
 * Eliminates the need for DataLoader promises, because resolvers are inherently batched.
 * Executes via flat queuing without deep recursion and huge call stacks.

--- a/lib/graphql/cardinal/executor.rb
+++ b/lib/graphql/cardinal/executor.rb
@@ -226,7 +226,9 @@ module GraphQL
           # build leaf results
           resolved_sources.each_with_index do |val, i|
             # DANGER: HOT PATH!
-            parent_responses[i][field_key] = if val.nil? || val.is_a?(StandardError)
+            response = parent_responses[i]
+            lazy_field_keys.each { |k| response[k] = nil } if lazy_field_keys && !lazy_field_keys.empty?
+            response[field_key] = if val.nil? || val.is_a?(StandardError)
               build_missing_value(field_type, val)
             elsif return_type.kind.scalar?
               coerce_scalar_value(return_type, val)

--- a/lib/graphql/cardinal/executor/response_shape.rb
+++ b/lib/graphql/cardinal/executor/response_shape.rb
@@ -26,9 +26,7 @@ module GraphQL::Cardinal
             begin
               node_type = @query.get_field(parent_type, node.name).type
               named_type = node_type.unwrap
-
-              # delete and re-add to order result keys...
-              raw_value = raw_object.delete(field_name)
+              raw_value = raw_object[field_name]
 
               raw_object[field_name] = if raw_value.is_a?(ExecutionError)
                 # capture errors encountered in the response with proper path

--- a/lib/graphql/cardinal/field_resolvers.rb
+++ b/lib/graphql/cardinal/field_resolvers.rb
@@ -18,7 +18,11 @@ module GraphQL
       end
 
       def resolve(objects, _args, _ctx, _scope)
-        objects.map { _1[@key] }
+        objects.map do |hash|
+          hash[@key]
+        rescue StandardError => e
+          InternalError.new
+        end
       end
     end
 


### PR DESCRIPTION
Inlines selection order concerns with virtually no overhead, which speeds up the lazy execution benchmark by eliminating the associated shaping pass.

```
Before:
graphql-cardinal: 140002 lazy resolvers
    1.729 (± 0.0%) i/s  (578.29 ms/i) -      9.000 in   5.205185s

After:
graphql-cardinal: 140002 lazy resolvers
    2.025 (± 0.0%) i/s  (493.78 ms/i) -     11.000 in   5.433050s
```

This solution won't hold up to async field executions, but we can cross that bridge when we get there. For now, we have fast ordered keys.