### PR TITLE
Guided error formatter

### DIFF
--- a/lib/graphql/cardinal/executor/execution_field.rb
+++ b/lib/graphql/cardinal/executor/execution_field.rb
@@ -4,18 +4,26 @@ module GraphQL::Cardinal
   class Executor
     class ExecutionField
       attr_reader :key, :node
-      attr_accessor :type, :promise
+      attr_accessor :scope, :type, :result
 
-      def initialize(key)
+      def initialize(key, scope = nil)
         @key = key.freeze
+        @scope = scope
+        @name = nil
         @node = nil
         @nodes = nil
+        @type = nil
+        @result = nil
         @arguments = nil
-        @promise = nil
+        @path = nil
       end
 
       def name
         @name ||= @node.name.freeze
+      end
+
+      def path
+        @path ||= (@scope ? [*@scope.path, @key] : []).freeze
       end
 
       def add_node(n)

--- a/lib/graphql/cardinal/executor/hot_paths.rb
+++ b/lib/graphql/cardinal/executor/hot_paths.rb
@@ -5,22 +5,22 @@ module GraphQL::Cardinal
     module HotPaths
       # DANGER: HOT PATH!
       # Overhead added here scales dramatically...
-      def build_composite_response(field_type, source, next_sources, next_responses)
+      def build_composite_response(exec_field, current_type, source, next_sources, next_responses)
         # if object authorization check implemented, then...
         # unless Authorization.can_access_object?(return_type, source, @context)
 
         if source.nil? || source.is_a?(ExecutionError)
-          build_missing_value(field_type, source)
-        elsif field_type.list?
+          build_missing_value(exec_field, current_type, source)
+        elsif current_type.list?
           unless source.is_a?(Array)
-            report_exception("Incorrect result for list field. Expected Array, got #{source.class}")
-            return build_missing_value(field_type, nil)
+            report_exception("Incorrect result for list field. Expected Array, got #{source.class}", field: exec_field)
+            return build_missing_value(exec_field, current_type, nil)
           end
 
-          field_type = field_type.of_type while field_type.non_null?
+          current_type = current_type.of_type while current_type.non_null?
 
           source.map do |src|
-            build_composite_response(field_type.of_type, src, next_sources, next_responses)
+            build_composite_response(exec_field, current_type.of_type, src, next_sources, next_responses)
           end
         else
           next_sources << source
@@ -31,15 +31,14 @@ module GraphQL::Cardinal
 
       # DANGER: HOT PATH!
       # Overhead added here scales dramatically...
-      def build_missing_value(field_type, val)
+      def build_missing_value(exec_field, current_type, val)
         # the provided value should always be nil or an error object
-
-        if field_type.non_null?
-          val ||= InvalidNullError.new(path: @path.dup)
+        if current_type.non_null?
+          val ||= InvalidNullError.new(path: exec_field.path)
         end
 
         if val
-          val.replace_path(@path.dup) unless val.path
+          val.replace_path(exec_field.path) unless val.path
           @errors << val unless val.base_error?
         end
 

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -38,6 +38,7 @@ SDL = <<~SCHEMA
     products(first: Int): ProductConnection
     nodes(ids: [ID!]!): [Node]!
     node(id: ID!): Node
+    noResolver: String
   }
 
   type WriteValuePayload {
@@ -325,4 +326,3 @@ BASIC_SOURCE = {
     }],
   },
 }
-

--- a/test/graphql/cardinal/executor/abstracts_test.rb
+++ b/test/graphql/cardinal/executor/abstracts_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GraphQL::Cardinal::Executor::AbstractsTest < Minitest::Test
+  def test_abstract_type_object_access
+    document = %|{
+      node(id: "Product/1") {
+        ... on Product { id }
+        __typename
+      }
+    }|
+
+    source = {
+      "node" => { "id" => "Product/1", "__typename__" => "Product" },
+    }
+
+    expected = {
+      "node" => { "id" => "Product/1", "__typename" => "Product" },
+    }
+
+    assert_equal expected, breadth_exec(document, source).dig("data")
+  end
+
+  def test_abstract_type_list_access
+    document = %|{
+      nodes(ids: ["Product/1", "Variant/1"]) {
+        __typename
+        ... on Product {
+          id
+        }
+        ... on Variant {
+          title
+        }
+      }
+    }|
+
+    source = {
+      "nodes" => [
+        { "id" => "Product/1", "title" => "Product 1", "__typename__" => "Product" },
+        { "id" => "Variant/1", "title" => "Variant 1", "__typename__" => "Variant" },
+      ],
+    }
+
+    expected = {
+      "nodes" => [
+        { "id" => "Product/1", "__typename" => "Product" },
+        { "title" => "Variant 1", "__typename" => "Variant" },
+      ],
+    }
+
+    assert_equal expected, breadth_exec(document, source).dig("data")
+  end
+end

--- a/test/graphql/cardinal/executor/aggregate_selections_test.rb
+++ b/test/graphql/cardinal/executor/aggregate_selections_test.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GraphQL::Cardinal::Executor::AggregateSelectionsTest < Minitest::Test
+  NODE_SOURCE = {
+    "node" => {
+      "title" => "Banana",
+      "metafield" => { "key" => "test", "value" => "okay" },
+      "__typename__" => "Product",
+    },
+  }.freeze
+
+  NODE_EXPECTED = {
+    "node" => {
+      "title" => "Banana",
+      "metafield" => { "key" => "test", "value" => "okay" },
+    },
+  }.freeze
+
+  def test_aggregate_field_selections
+    document = %|{
+      products(first: 1) {
+        nodes {
+          title
+          metafield(key: "test") {
+            key
+          }
+          metafield(key: "test") {
+            value
+          }
+        }
+      }
+    }|
+
+    source = {
+      "products" => {
+        "nodes" => [{
+          "title" => "Banana",
+          "metafield" => { "key" => "test", "value" => "okay" },
+        }],
+      },
+    }
+
+    assert_equal source, breadth_exec(document, source).dig("data")
+  end
+
+  def test_aggregate_field_access_across_inline_fragments
+    document = %|{
+      node(id: "Product/1") {
+        ... on Product {
+          title
+          metafield(key: "test") {
+            key
+          }
+        }
+        ...on HasMetafields {
+          metafield(key: "test") {
+            value
+          }
+        }
+      }
+    }|
+
+    assert_equal NODE_EXPECTED, breadth_exec(document, NODE_SOURCE).dig("data")
+  end
+
+  def test_aggregate_field_access_across_fragment_spreads
+    document = %|{
+      node(id: "Product/1") {
+        ... ProductAttrs
+        ... HasMetafieldsAttrs
+      }
+    }
+    fragment ProductAttrs on Product {
+      title
+      metafield(key: "test") {
+        key
+      }
+    }
+    fragment HasMetafieldsAttrs on HasMetafields {
+      metafield(key: "test") {
+        value
+      }
+    }|
+
+    assert_equal NODE_EXPECTED, breadth_exec(document, NODE_SOURCE).dig("data")
+  end
+end

--- a/test/graphql/cardinal/executor/arguments_test.rb
+++ b/test/graphql/cardinal/executor/arguments_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GraphQL::Cardinal::Executor::ArgumentsTest < Minitest::Test
+  def test_arguments_receive_string_variables
+    document = %|mutation($value: String!) {
+      writeValue(value: $value) {
+        value
+      }
+    }|
+
+    source = { "writeValue" => { "value" => nil } }
+    expected = { "writeValue" => { "value" => "success!" } }
+    assert_equal expected, breadth_exec(document, source, variables: { "value" => "success!" }).dig("data")
+  end
+
+  def test_arguments_receive_symbol_variables
+    document = %|mutation($value: String!) {
+      writeValue(value: $value) {
+        value
+      }
+    }|
+
+    source = { "writeValue" => { "value" => nil } }
+    expected = { "writeValue" => { "value" => "success!" } }
+    assert_equal expected, breadth_exec(document, source, variables: { value: "success!" }).dig("data")
+  end
+end

--- a/test/graphql/cardinal/executor/conditionals_test.rb
+++ b/test/graphql/cardinal/executor/conditionals_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GraphQL::Cardinal::Executor::ConditionalsTest < Minitest::Test
+  SOURCE = {
+    "products" => {
+      "nodes" => [
+        { "id" => "Product/1", "title" => "Product 1" },
+        { "id" => "Product/2", "title" => "Product 2" },
+      ],
+    },
+  }.freeze
+
+  SKIPPED_SOURCE = {
+    "products" => {
+      "nodes" => [
+        { "id" => "Product/1" },
+        { "id" => "Product/2" },
+      ],
+    },
+  }.freeze
+
+  def test_follows_skip_directive_omissions
+    document = %|{
+      products(first: 3) {
+        nodes {
+          id
+          title @skip(if: true)
+        }
+      }
+    }|
+
+    assert_equal SKIPPED_SOURCE, breadth_exec(document, SOURCE).dig("data")
+  end
+
+  def test_follows_skip_directive_inclusions
+    document = %|{
+      products(first: 3) {
+        nodes {
+          id
+          title @skip(if: false)
+        }
+      }
+    }|
+
+    assert_equal SOURCE, breadth_exec(document, SOURCE).dig("data")
+  end
+
+  def test_follows_skip_directives_with_string_variable
+    document = %|query($skip: Boolean!) {
+      products(first: 3) {
+        nodes {
+          id
+          title @skip(if: $skip)
+        }
+      }
+    }|
+
+    assert_equal SKIPPED_SOURCE, breadth_exec(document, SOURCE, variables: { "skip" => true }).dig("data")
+  end
+
+  def test_follows_skip_directives_with_symbol_variable
+    document = %|query($skip: Boolean!) {
+      products(first: 3) {
+        nodes {
+          id
+          title @skip(if: $skip)
+        }
+      }
+    }|
+
+    assert_equal SKIPPED_SOURCE, breadth_exec(document, SOURCE, variables: { skip: true }).dig("data")
+  end
+
+  def test_follows_include_directive_omissions
+    document = %|{
+      products(first: 3) {
+        nodes {
+          id
+          title @include(if: false)
+        }
+      }
+    }|
+
+    assert_equal SKIPPED_SOURCE, breadth_exec(document, SOURCE).dig("data")
+  end
+
+  def test_follows_include_directive_inclusions
+    document = %|{
+      products(first: 3) {
+        nodes {
+          id
+          title @include(if: true)
+        }
+      }
+    }|
+
+    assert_equal SOURCE, breadth_exec(document, SOURCE).dig("data")
+  end
+
+  def test_follows_include_directives_with_string_variable
+    document = %|query($include: Boolean!) {
+      products(first: 3) {
+        nodes {
+          id
+          title @include(if: $include)
+        }
+      }
+    }|
+
+    assert_equal SKIPPED_SOURCE, breadth_exec(document, SOURCE, variables: { "include" => false }).dig("data")
+  end
+
+  def test_follows_include_directives_with_symbol_variable
+    document = %|query($include: Boolean!) {
+      products(first: 3) {
+        nodes {
+          id
+          title @include(if: $include)
+        }
+      }
+    }|
+
+    assert_equal SKIPPED_SOURCE, breadth_exec(document, SOURCE, variables: { include: false }).dig("data")
+  end
+end

--- a/test/graphql/cardinal/executor/fragments_test.rb
+++ b/test/graphql/cardinal/executor/fragments_test.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GraphQL::Cardinal::Executor::FragmentsTest < Minitest::Test
+  SOURCE = {
+    "products" => {
+      "nodes" => [{
+        "title" => "Banana",
+        "metafield" => { "key" => "test", "value" => "okay" },
+      }],
+    },
+  }.freeze
+
+  def test_selects_via_inline_fragments
+    document = %|{
+      products(first: 1) {
+        nodes {
+          ... on Product { title }
+        }
+      }
+    }|
+
+    expected = {
+      "products" => {
+        "nodes" => [{ "title" => "Banana" }],
+      },
+    }
+
+    assert_equal expected, breadth_exec(document, SOURCE).dig("data")
+  end
+
+  def test_selects_via_fragment_spreads
+    document = %|{
+      products(first: 1) {
+        nodes {
+          ... ProductAttrs
+        }
+      }
+    }
+    fragment ProductAttrs on Product {
+      title
+    }|
+
+    expected = {
+      "products" => {
+        "nodes" => [{ "title" => "Banana" }],
+      },
+    }
+
+    assert_equal expected, breadth_exec(document, SOURCE).dig("data")
+  end
+
+  def test_selects_via_nested_fragments
+    document = %|{
+      products(first: 1) {
+        nodes {
+          ... on Product {
+            ... ProductAttrs
+          }
+        }
+      }
+    }
+    fragment ProductAttrs on Product {
+      ... on Product { title }
+    }|
+
+    expected = {
+      "products" => {
+        "nodes" => [{ "title" => "Banana" }],
+      },
+    }
+
+    assert_equal expected, breadth_exec(document, SOURCE).dig("data")
+  end
+
+  def test_selects_via_abstract_fragments
+    document = %|{
+      products(first: 1) {
+        nodes {
+          ... on HasMetafields {
+            metafield(key: "test") { key value }
+          }
+        }
+      }
+    }|
+
+    expected = {
+      "products" => {
+        "nodes" => [{
+          "metafield" => { "key" => "test", "value" => "okay" },
+        }],
+      },
+    }
+
+    assert_equal expected, breadth_exec(document, SOURCE).dig("data")
+  end
+end

--- a/test/graphql/cardinal/executor_test.rb
+++ b/test/graphql/cardinal/executor_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class GraphQL::Cardinal::ExecutorTest < Minitest::Test
-  def test_runs
+  def test_resolves_basic_query
     assert_equal BASIC_SOURCE, breadth_exec(BASIC_DOCUMENT, BASIC_SOURCE).dig("data")
   end
 
@@ -20,9 +20,7 @@ class GraphQL::Cardinal::ExecutorTest < Minitest::Test
     }|
 
     source = {
-      "products" => {
-        "nodes" => [{}],
-      },
+      "products" => { "nodes" => [{}] },
       "node" => { "__typename__" => "Product" },
     }
 
@@ -36,166 +34,7 @@ class GraphQL::Cardinal::ExecutorTest < Minitest::Test
     assert_equal expected, breadth_exec(document, source).dig("data")
   end
 
-  def test_follows_skip_directives
-    document = %|{
-      products(first: 3) {
-        nodes {
-          id
-          title @skip(if: true)
-        }
-      }
-    }|
-
-    source = {
-      "products" => {
-        "nodes" => [
-          { "id" => "Product/1" },
-          { "id" => "Product/2" },
-        ],
-      },
-    }
-
-    assert_equal source, breadth_exec(document, source).dig("data")
-  end
-
-  def test_follows_include_directives
-    document = %|{
-      products(first: 3) {
-        nodes {
-          id
-          title @include(if: false)
-        }
-      }
-    }|
-
-    source = {
-      "products" => {
-        "nodes" => [
-          { "id" => "Product/1" },
-          { "id" => "Product/2" },
-        ],
-      },
-    }
-
-    assert_equal source, breadth_exec(document, source).dig("data")
-  end
-
-  def test_aggregate_field_access
-    document = %|{
-      node(id: "Product/1") {
-        ... on Product {
-          title
-          metafield(key: "test") {
-            key
-          }
-          metafield(key: "test") {
-            value
-          }
-        }
-      }
-    }|
-
-    source = {
-      "node" => {
-        "title" => "Banana",
-        "metafield" => { "key" => "test", "value" => "okay" },
-        "__typename__" => "Product",
-      },
-    }
-
-    expected = {
-      "node" => {
-        "title" => "Banana",
-        "metafield" => { "key" => "test", "value" => "okay" },
-      },
-    }
-
-    assert_equal expected, breadth_exec(document, source).dig("data")
-  end
-
-  def test_aggregate_field_access_across_fragments
-    document = %|{
-      node(id: "Product/1") {
-        ... on Product {
-          title
-          metafield(key: "test") {
-            key
-          }
-        }
-        ...on HasMetafields {
-          metafield(key: "test") {
-            value
-          }
-        }
-      }
-    }|
-
-    source = {
-      "node" => {
-        "title" => "Banana",
-        "metafield" => { "key" => "test", "value" => "okay" },
-        "__typename__" => "Product",
-      },
-    }
-
-    expected = {
-      "node" => {
-        "title" => "Banana",
-        "metafield" => { "key" => "test", "value" => "okay" },
-      },
-    }
-
-    assert_equal expected, breadth_exec(document, source).dig("data")
-  end
-
-  def test_abstract_type_object_access
-    document = %|{
-      node(id: "Product/1") {
-        ... on Product { id }
-      }
-    }|
-
-    source = {
-      "node" => { "id" => "Product/1", "__typename__" => "Product" },
-    }
-
-    expected = {
-      "node" => { "id" => "Product/1" },
-    }
-
-    assert_equal expected, breadth_exec(document, source).dig("data")
-  end
-
-  def test_abstract_type_list_access
-    document = %|{
-      nodes(ids: ["Product/1", "Variant/1"]) {
-        ... on Product {
-          id
-        }
-        ... on Variant {
-          title
-        }
-      }
-    }|
-
-    source = {
-      "nodes" => [
-        { "id" => "Product/1", "title" => "Product 1", "__typename__" => "Product" },
-        { "id" => "Variant/1", "title" => "Variant 1", "__typename__" => "Variant" },
-      ],
-    }
-
-    expected = {
-      "nodes" => [
-        { "id" => "Product/1" },
-        { "title" => "Variant 1" },
-      ],
-    }
-
-    assert_equal expected, breadth_exec(document, source).dig("data")
-  end
-
-  def test_serial_mutations
+  def test_mutations_run_serially
     document = %|mutation {
       a: writeValue(value: "test1") {
         value
@@ -219,5 +58,27 @@ class GraphQL::Cardinal::ExecutorTest < Minitest::Test
     }
 
     assert_equal expected, breadth_exec(document, source).dig("data")
+  end
+
+  def test_subscriptions_not_supported
+    document = %|subscription {
+      onWriteValue { value }
+    }|
+
+    error = assert_raises(GraphQL::Cardinal::DocumentError) do
+      breadth_exec(document, {})
+    end
+
+    assert_equal "Unsupported operation type: subscription", error.message
+  end
+
+  def test_raises_not_implemented_for_missing_resolvers
+    document = %|{ noResolver }|
+
+    error = assert_raises(NotImplementedError) do
+      breadth_exec(document, {})
+    end
+
+    assert_equal "No field resolver for 'Query.noResolver'", error.message
   end
 end

--- a/test/graphql/cardinal/promise_test.rb
+++ b/test/graphql/cardinal/promise_test.rb
@@ -1,0 +1,364 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GraphQL::Cardinal::PromiseTest < Minitest::Test
+  def setup
+    @promise = GraphQL::Cardinal::Promise.new
+  end
+
+  def test_initial_state_is_pending
+    assert_predicate @promise, :pending?
+    refute_predicate @promise, :resolved?
+    refute_predicate @promise, :rejected?
+    assert_nil @promise.value
+    assert_nil @promise.reason
+  end
+
+  def test_resolve_changes_state_to_fulfilled
+    @promise.send(:resolve, "test value")
+
+    assert_predicate @promise, :resolved?
+    refute_predicate @promise, :pending?
+    refute_predicate @promise, :rejected?
+    assert_equal "test value", @promise.value
+    assert_nil @promise.reason
+  end
+
+  def test_reject_changes_state_to_rejected
+    error = StandardError.new("test error")
+    @promise.send(:reject, error)
+
+    assert_predicate @promise, :rejected?
+    refute_predicate @promise, :pending?
+    refute_predicate @promise, :resolved?
+    assert_nil @promise.value
+    assert_equal error, @promise.reason
+  end
+
+  def test_cannot_resolve_already_resolved_promise
+    @promise.send(:resolve, "first value")
+    @promise.send(:resolve, "second value")
+
+    assert_equal "first value", @promise.value
+  end
+
+  def test_cannot_reject_already_resolved_promise
+    @promise.send(:resolve, "value")
+    error = StandardError.new("error")
+    @promise.send(:reject, error)
+
+    assert_predicate @promise, :resolved?
+    assert_equal "value", @promise.value
+    assert_nil @promise.reason
+  end
+
+  def test_cannot_resolve_already_rejected_promise
+    error = StandardError.new("error")
+    @promise.send(:reject, error)
+    @promise.send(:resolve, "value")
+
+    assert_predicate @promise, :rejected?
+    assert_equal error, @promise.reason
+    assert_nil @promise.value
+  end
+
+  def test_cannot_reject_already_rejected_promise
+    error1 = StandardError.new("first error")
+    error2 = StandardError.new("second error")
+    @promise.send(:reject, error1)
+    @promise.send(:reject, error2)
+
+    assert_equal error1, @promise.reason
+  end
+
+  def test_constructor_with_block_resolves
+    promise = GraphQL::Cardinal::Promise.new do |resolve, reject|
+      resolve.call("test value")
+    end
+
+    assert_predicate promise, :resolved?
+    assert_equal "test value", promise.value
+  end
+
+  def test_constructor_with_block_rejects
+    error = StandardError.new("test error")
+    promise = GraphQL::Cardinal::Promise.new do |resolve, reject|
+      reject.call(error)
+    end
+
+    assert_predicate promise, :rejected?
+    assert_equal error, promise.reason
+  end
+
+  def test_constructor_with_block_catches_exceptions
+    promise = GraphQL::Cardinal::Promise.new do |resolve, reject|
+      raise StandardError.new("test error")
+    end
+
+    assert_predicate promise, :rejected?
+    assert_instance_of StandardError, promise.reason
+    assert_equal "test error", promise.reason.message
+  end
+
+  def test_then_with_fulfilled_promise
+    @promise.send(:resolve, "original value")
+
+    result_promise = @promise.then { |value| "transformed: #{value}" }
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "transformed: original value", result_promise.value
+  end
+
+  def test_then_with_rejected_promise
+    error = StandardError.new("original error")
+    @promise.send(:reject, error)
+
+    result_promise = @promise.then(
+      ->(value) { "should not be called" },
+      ->(reason) { "handled: #{reason.message}" }
+    )
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "handled: original error", result_promise.value
+  end
+
+  def test_then_with_pending_promise
+    fulfilled_called = false
+    rejected_called = false
+
+    result_promise = @promise.then(
+      ->(value) { fulfilled_called = true; "fulfilled: #{value}" },
+      ->(reason) { rejected_called = true; "rejected: #{reason.message}" }
+    )
+
+    assert_predicate result_promise, :pending?
+    refute fulfilled_called
+    refute rejected_called
+
+    @promise.send(:resolve, "test value")
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "fulfilled: test value", result_promise.value
+    assert fulfilled_called
+    refute rejected_called
+  end
+
+  def test_then_with_pending_promise_rejected
+    fulfilled_called = false
+    rejected_called = false
+
+    result_promise = @promise.then(
+      ->(value) { fulfilled_called = true; "fulfilled: #{value}" },
+      ->(reason) { rejected_called = true; "rejected: #{reason.message}" }
+    )
+
+    error = StandardError.new("test error")
+    @promise.send(:reject, error)
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "rejected: test error", result_promise.value
+    refute fulfilled_called
+    assert rejected_called
+  end
+
+  def test_then_catches_exceptions_in_fulfilled_handler
+    @promise.send(:resolve, "test value")
+
+    result_promise = @promise.then { |value| raise StandardError.new("handler error") }
+
+    assert_predicate result_promise, :rejected?
+    assert_instance_of StandardError, result_promise.reason
+    assert_equal "handler error", result_promise.reason.message
+  end
+
+  def test_then_catches_exceptions_in_rejected_handler
+    @promise.send(:reject, StandardError.new("original error"))
+
+    result_promise = @promise.then(
+      ->(value) { "should not be called" },
+      ->(reason) { raise StandardError.new("handler error") }
+    )
+
+    assert_predicate result_promise, :rejected?
+    assert_instance_of StandardError, result_promise.reason
+    assert_equal "handler error", result_promise.reason.message
+  end
+
+  def test_then_returns_promise_from_fulfilled_handler
+    inner_promise = GraphQL::Cardinal::Promise.new
+    @promise.send(:resolve, "test value")
+
+    result_promise = @promise.then { |value| inner_promise }
+
+    assert_predicate result_promise, :pending?
+
+    inner_promise.send(:resolve, "inner value")
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "inner value", result_promise.value
+  end
+
+  def test_then_returns_promise_from_rejected_handler
+    inner_promise = GraphQL::Cardinal::Promise.new
+    @promise.send(:reject, StandardError.new("original error"))
+
+    result_promise = @promise.then(
+      ->(value) { "should not be called" },
+      ->(reason) { inner_promise }
+    )
+
+    assert_predicate result_promise, :pending?
+
+    inner_promise.send(:resolve, "recovered value")
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "recovered value", result_promise.value
+  end
+
+  def test_then_requires_fulfilled_handler_or_block
+    assert_raises ArgumentError do
+      @promise.then
+    end
+  end
+
+  def test_then_forbids_both_fulfilled_handler_and_block
+    assert_raises ArgumentError do
+      @promise.then(->(v) { v }) { |v| v }
+    end
+  end
+
+  def test_catch_handles_rejected_promise
+    error = StandardError.new("test error")
+    @promise.send(:reject, error)
+
+    result_promise = @promise.catch { |reason| "caught: #{reason.message}" }
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "caught: test error", result_promise.value
+  end
+
+  def test_catch_passes_through_resolved_promise
+    @promise.send(:resolve, "test value")
+
+    result_promise = @promise.catch { |reason| "should not be called" }
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "test value", result_promise.value
+  end
+
+    def test_promise_resolve_creates_resolved_promise
+    result_promise = GraphQL::Cardinal::Promise.resolve("test value")
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "test value", result_promise.value
+  end
+
+  def test_all_with_empty_array
+    result_promise = GraphQL::Cardinal::Promise.all([])
+
+    assert_predicate result_promise, :resolved?
+    assert_equal [], result_promise.value
+  end
+
+  def test_all_with_single_resolved_promise
+    promise1 = GraphQL::Cardinal::Promise.new
+    promise1.send(:resolve, "value1")
+
+    result_promise = GraphQL::Cardinal::Promise.all([promise1])
+
+    assert_predicate result_promise, :resolved?
+    assert_equal ["value1"], result_promise.value
+  end
+
+  def test_all_with_multiple_resolved_promises
+    promise1 = GraphQL::Cardinal::Promise.new
+    promise2 = GraphQL::Cardinal::Promise.new
+    promise3 = GraphQL::Cardinal::Promise.new
+
+    promise1.send(:resolve, "value1")
+    promise2.send(:resolve, "value2")
+    promise3.send(:resolve, "value3")
+
+    result_promise = GraphQL::Cardinal::Promise.all([promise1, promise2, promise3])
+
+    assert_predicate result_promise, :resolved?
+    assert_equal ["value1", "value2", "value3"], result_promise.value
+  end
+
+  def test_all_with_pending_promises
+    promise1 = GraphQL::Cardinal::Promise.new
+    promise2 = GraphQL::Cardinal::Promise.new
+    promise3 = GraphQL::Cardinal::Promise.new
+
+    result_promise = GraphQL::Cardinal::Promise.all([promise1, promise2, promise3])
+
+    assert_predicate result_promise, :pending?
+
+    promise1.send(:resolve, "value1")
+    assert_predicate result_promise, :pending?
+
+    promise2.send(:resolve, "value2")
+    assert_predicate result_promise, :pending?
+
+    promise3.send(:resolve, "value3")
+    assert_predicate result_promise, :resolved?
+    assert_equal ["value1", "value2", "value3"], result_promise.value
+  end
+
+  def test_all_rejects_if_any_promise_rejects
+    promise1 = GraphQL::Cardinal::Promise.new
+    promise2 = GraphQL::Cardinal::Promise.new
+    promise3 = GraphQL::Cardinal::Promise.new
+
+    result_promise = GraphQL::Cardinal::Promise.all([promise1, promise2, promise3])
+
+    promise1.send(:resolve, "value1")
+    error = StandardError.new("test error")
+    promise2.send(:reject, error)
+    promise3.send(:resolve, "value3")
+
+    assert_predicate result_promise, :rejected?
+    assert_equal error, result_promise.reason
+  end
+
+  def test_all_maintains_order
+    promise1 = GraphQL::Cardinal::Promise.new
+    promise2 = GraphQL::Cardinal::Promise.new
+    promise3 = GraphQL::Cardinal::Promise.new
+
+    result_promise = GraphQL::Cardinal::Promise.all([promise1, promise2, promise3])
+
+    # Resolve in different order
+    promise3.send(:resolve, "value3")
+    promise1.send(:resolve, "value1")
+    promise2.send(:resolve, "value2")
+
+    assert_predicate result_promise, :resolved?
+    assert_equal ["value1", "value2", "value3"], result_promise.value
+  end
+
+  def test_chaining_then_calls
+    @promise.send(:resolve, 1)
+
+    result_promise = @promise
+      .then { |value| value + 1 }
+      .then { |value| value * 2 }
+      .then { |value| "result: #{value}" }
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "result: 4", result_promise.value
+  end
+
+  def test_error_propagation_through_chain
+    @promise.send(:resolve, "test")
+
+    result_promise = @promise
+      .then { |value| raise StandardError.new("chain error") }
+      .then { |value| "should not be called" }
+      .catch { |error| "caught: #{error.message}" }
+
+    assert_predicate result_promise, :resolved?
+    assert_equal "caught: chain error", result_promise.value
+  end
+end


### PR DESCRIPTION
* Fixes execution paths (weren't stacking as execution progressed)
* Guides the error formatter to only follow response paths with errors.
* Simplifies the flow of lazy handling.
* Adds significant test coverage.